### PR TITLE
update deploy script: use arkb instead of irys

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "irys upload-dir dist -w ~/.wallet.json -t arweave -h https://turbo.ardrive.io --index-file index.html"
+    "deploy": "arkb deploy dist --wallet ./wallet.json"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.0",


### PR DESCRIPTION
The deploy method for irys wasn’t working, so I switched the deployment script to use arkb to keep it consistent with the README.md.