### PR TITLE
Update calc-confidence-value.js

### DIFF
--- a/server/lib/calc-confidence-value.js
+++ b/server/lib/calc-confidence-value.js
@@ -1,7 +1,7 @@
 const VERIFIED_WEIGHT = 1;
 
 const CUTOFF_PARAMS = {
-  'followers_count': 100,
+  'followers_count': 10,
   'tweet_count': 10,
   // 'listed_count': 0,
   // 'like_count': 100,


### PR DESCRIPTION
Lowering followers cutoff from 100 to 10. Some real people with twitter account of less than 100 followers should be able to vouch. They will still get a low vouch value, but I think is more fair to still give them some points.